### PR TITLE
Refactor field reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .idea/
 *.iml
 *.iws
+out/
+
 
 # Mac
 .DS_Store
@@ -14,6 +16,10 @@
 # Maven
 log/
 target/
+
+# Gradle
+build/
+.gradle/
 
 # Application
 test-indices/

--- a/simple-lucene-annotations/src/main/java/io/github/iamnicknack/slc/annotation/AnnotatedRecordOperations.java
+++ b/simple-lucene-annotations/src/main/java/io/github/iamnicknack/slc/annotation/AnnotatedRecordOperations.java
@@ -72,9 +72,7 @@ public interface AnnotatedRecordOperations<T extends Record> extends DomainOpera
             @Override
             public Object[] apply(Document document) {
                 return accessors.stream()
-                        .map(accessorDescriptor -> accessorDescriptor.fieldDescriptor()
-                                .read(document.getFields(accessorDescriptor.fieldDescriptor().name()))
-                        )
+                        .map(accessorDescriptor -> accessorDescriptor.fieldDescriptor().read(document))
                         .toArray();
             }
         };

--- a/simple-lucene-api/src/main/java/io/github/iamnicknack/slc/api/document/FieldReader.java
+++ b/simple-lucene-api/src/main/java/io/github/iamnicknack/slc/api/document/FieldReader.java
@@ -1,9 +1,20 @@
 package io.github.iamnicknack.slc.api.document;
 
-import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.document.Document;
 
+/**
+ * The {@code FieldReader} is used to provide individual domain property values from a {@link Document}.
+ *
+ * <p>These could either be simple Java types that are stored as single field, or complex types which require
+ * more than one document field to store their representation.</p>
+ */
 public interface FieldReader {
 
-    Object read(IndexableField[] fields);
+    /**
+     * Read a value from the specified {@link Document}
+     * @param document the Lucene document
+     * @return the reconstructed domain value
+     */
+    Object read(Document document);
 
 }

--- a/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/document/FieldDescriptorBuilder.java
+++ b/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/document/FieldDescriptorBuilder.java
@@ -2,6 +2,7 @@ package io.github.iamnicknack.slc.core.document;
 
 import io.github.iamnicknack.slc.api.document.FieldDescriptor;
 import io.github.iamnicknack.slc.api.document.SubFieldDescriptor;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
 import io.github.iamnicknack.slc.api.document.FieldParser;
 import io.github.iamnicknack.slc.api.document.FieldReader;
@@ -195,8 +196,8 @@ public class FieldDescriptorBuilder {
                     .toList();
 
             FieldReader fieldReader = multiValue
-                    ? new MultiValueFieldReader(fieldParser())
-                    : new SingleValueFieldReader(fieldParser());
+                    ? new MultiValueFieldReader(name, fieldParser())
+                    : new SingleValueFieldReader(name, fieldParser());
 
             return new FieldDescriptorRecord<>(name,
                     id,
@@ -224,8 +225,6 @@ public class FieldDescriptorBuilder {
                                             FieldReader fieldReader,
                                             List<SubFieldDescriptor<T>> subfields) implements FieldDescriptor<T> {
 
-
-
         @Override
         @SuppressWarnings("unchecked")
         public Iterable<IndexableField> fields(Object value) {
@@ -252,8 +251,8 @@ public class FieldDescriptorBuilder {
 
         @Override
         @SuppressWarnings("unchecked")
-        public T read(IndexableField[] fields) {
-            return (T)fieldReader.read(fields);
+        public T read(Document document) {
+            return (T)fieldReader.read(document);
         }
     }
 }

--- a/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/document/MultiValueFieldReader.java
+++ b/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/document/MultiValueFieldReader.java
@@ -1,6 +1,6 @@
 package io.github.iamnicknack.slc.core.document;
 
-import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.document.Document;
 import io.github.iamnicknack.slc.api.document.FieldParser;
 import io.github.iamnicknack.slc.api.document.FieldReader;
 
@@ -9,15 +9,17 @@ import java.util.List;
 
 public class MultiValueFieldReader implements FieldReader {
 
+    private final String name;
     private final FieldParser<?> parser;
 
-    public MultiValueFieldReader(FieldParser<?> parser) {
+    public MultiValueFieldReader(String name, FieldParser<?> parser) {
+        this.name = name;
         this.parser = parser;
     }
 
     @Override
-    public List<?> read(IndexableField[] fields) {
-        return Arrays.stream(fields)
+    public List<?> read(Document document) {
+        return Arrays.stream(document.getFields(name))
                 .map(parser::parse)
                 .toList();
     }

--- a/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/document/SingleValueFieldReader.java
+++ b/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/document/SingleValueFieldReader.java
@@ -1,6 +1,6 @@
 package io.github.iamnicknack.slc.core.document;
 
-import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.document.Document;
 import io.github.iamnicknack.slc.api.document.FieldParser;
 import io.github.iamnicknack.slc.api.document.FieldReader;
 
@@ -8,15 +8,17 @@ import java.util.Arrays;
 
 public class SingleValueFieldReader implements FieldReader {
 
+    private final String name;
     private final FieldParser<?> parser;
 
-    public SingleValueFieldReader(FieldParser<?> parser) {
+    public SingleValueFieldReader(String name, FieldParser<?> parser) {
+        this.name = name;
         this.parser = parser;
     }
 
     @Override
-    public Object read(IndexableField[] fields) {
-        return Arrays.stream(fields)
+    public Object read(Document document) {
+        return Arrays.stream(document.getFields(name))
                 .findFirst()
                 .map(parser::parse)
                 .orElse(null);

--- a/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/index/MapDomainOperations.java
+++ b/simple-lucene-core/src/main/java/io/github/iamnicknack/slc/core/index/MapDomainOperations.java
@@ -5,7 +5,7 @@ import io.github.iamnicknack.slc.api.document.FieldDescriptor;
 import io.github.iamnicknack.slc.api.index.DomainOperations;
 import org.apache.lucene.document.Document;
 
-import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -59,11 +59,8 @@ public class MapDomainOperations implements DomainOperations<Map<String, Object>
     public Map<String, Object> readDocument(Document document) {
 
         return documentDescriptor.fieldMap().entrySet().stream()
-                .map(descriptorEntry -> {
-                    var fields = document.getFields(descriptorEntry.getKey());
-                    return new AbstractMap.SimpleEntry<>(descriptorEntry.getKey(), descriptorEntry.getValue().read(fields));
-                })
+                .map(descriptorEntry -> new SimpleEntry<>(descriptorEntry.getKey(), descriptorEntry.getValue().read(document)))
                 .filter(e -> e.getValue() != null)
-                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+                .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
     }
 }


### PR DESCRIPTION
Allowing field reader access to any fields in the document rather than a pre-selected list. 

This will facilitate support for complex types (#8)